### PR TITLE
Integrate by .esproj

### DIFF
--- a/Template/Svelte.Dotnet.Template.sln
+++ b/Template/Svelte.Dotnet.Template.sln
@@ -5,26 +5,7 @@ VisualStudioVersion = 17.4.33205.214
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Svelte.Dotnet.Template.Server", "Svelte.Dotnet.Template\Svelte.Dotnet.Template.Server\Svelte.Dotnet.Template.Server.csproj", "{ED6656E0-57E2-4B27-BB53-B2E0A5554B93}"
 EndProject
-Project("{E24C65DC-7377-472B-9ABA-BC803B73C61A}") = "Svelte.Dotnet.Template.Client", "Svelte.Dotnet.Template\Svelte.Dotnet.Template.Client\", "{EB52133A-13B8-4C56-A581-540E7093CA94}"
-	ProjectSection(WebsiteProperties) = preProject
-		TargetFrameworkMoniker = ".NETFramework,Version%3Dv4.8"
-		Debug.AspNetCompiler.VirtualPath = "/localhost_52137"
-		Debug.AspNetCompiler.PhysicalPath = "Svelte.Dotnet.Template\Svelte.Dotnet.Template.Client\"
-		Debug.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_52137\"
-		Debug.AspNetCompiler.Updateable = "true"
-		Debug.AspNetCompiler.ForceOverwrite = "true"
-		Debug.AspNetCompiler.FixedNames = "false"
-		Debug.AspNetCompiler.Debug = "True"
-		Release.AspNetCompiler.VirtualPath = "/localhost_52137"
-		Release.AspNetCompiler.PhysicalPath = "Svelte.Dotnet.Template\Svelte.Dotnet.Template.Client\"
-		Release.AspNetCompiler.TargetPath = "PrecompiledWeb\localhost_52137\"
-		Release.AspNetCompiler.Updateable = "true"
-		Release.AspNetCompiler.ForceOverwrite = "true"
-		Release.AspNetCompiler.FixedNames = "false"
-		Release.AspNetCompiler.Debug = "False"
-		VWDPort = "52137"
-		SlnRelativePath = "Svelte.Dotnet.Template\Svelte.Dotnet.Template.Client\"
-	EndProjectSection
+Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "Svelte.Dotnet.Template.Client", "Svelte.Dotnet.Template\Svelte.Dotnet.Template.Client\Svelte.Dotnet.Template.Client.esproj", "{EB52133A-13B8-4C56-A581-540E7093CA94}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Template/Svelte.Dotnet.Template/.template.config/template.json
+++ b/Template/Svelte.Dotnet.Template/.template.config/template.json
@@ -26,9 +26,9 @@
   ],
   "groupIdentity": "Quickz.Templates",
   "primaryOutputs": [
-    //{
-    //  "path": "./Svelte.Dotnet.Template.Client/Svelte.Dotnet.Template.Client.csproj"
-    //},
+    {
+      "path": "./Svelte.Dotnet.Template.Client/Svelte.Dotnet.Template.Client.esproj"
+    },
     {
       "path": "./Svelte.Dotnet.Template.Server/Svelte.Dotnet.Template.Server.csproj"
     }

--- a/Template/Svelte.Dotnet.Template/Svelte.Dotnet.Template.Client/Svelte.Dotnet.Template.Client.esproj
+++ b/Template/Svelte.Dotnet.Template/Svelte.Dotnet.Template.Client/Svelte.Dotnet.Template.Client.esproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk/1.0.2348200">
+  
+  <PropertyGroup>
+    <StartupCommand>npm run dev</StartupCommand>
+    <JavaScriptTestRoot>src\</JavaScriptTestRoot>
+    <JavaScriptTestFramework>Jest</JavaScriptTestFramework>
+    <!-- Allows the build (or compile) script located on package.json to run on Build -->
+    <ShouldRunBuildScript>false</ShouldRunBuildScript>
+    <!-- Folder where production build objects will be placed -->
+    <BuildOutputFolder>$(MSBuildProjectDirectory)\dist</BuildOutputFolder>
+  </PropertyGroup>
+  
+</Project>

--- a/Template/Svelte.Dotnet.Template/Svelte.Dotnet.Template.Server/Properties/launchSettings.json
+++ b/Template/Svelte.Dotnet.Template/Svelte.Dotnet.Template.Server/Properties/launchSettings.json
@@ -13,20 +13,20 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7216",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
       }
     },
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7216;http://localhost:5019",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
       }
     },
     "IIS Express": {

--- a/Template/Svelte.Dotnet.Template/Svelte.Dotnet.Template.Server/Svelte.Dotnet.Template.Server.csproj
+++ b/Template/Svelte.Dotnet.Template/Svelte.Dotnet.Template.Server/Svelte.Dotnet.Template.Server.csproj
@@ -6,11 +6,23 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Svelte.Dotnet.Template.Server</RootNamespace>
     <AssemblyName>$(AssemblyName.Replace(' ', '_'))</AssemblyName>
+
+    <SpaRoot>..\Svelte.Dotnet.Template.Client</SpaRoot>
+    <SpaProxyLaunchCommand>npm run dev</SpaProxyLaunchCommand>
+    <SpaProxyServerUrl>http://localhost:5173</SpaProxyServerUrl>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaProxy">
+      <Version>8.*-*</Version>
+    </PackageReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Svelte.Dotnet.Template.Client\Svelte.Dotnet.Template.Client.esproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I configured the test to run successfully using only the command line below.

```bash
dotnet new svelte
cd *.Server
dotnet run
```

Additionally, it also solves this problem: https://github.com/Quickz/svelte-dotnet-template/issues/10